### PR TITLE
runltp_ng(ssh): Use differnt user then root

### DIFF
--- a/tools/runltp-ng/backend.pm
+++ b/tools/runltp-ng/backend.pm
@@ -385,7 +385,7 @@ sub ssh_start
 	sleep(1); #hack wait for prompt
 	wait_prompt($self);
 	if ($user ne 'root') {
-		run_string($self, "sudo su");
+		run_string($self, 'sudo /bin/sh');
 		wait_prompt($self);
 	}
 }
@@ -393,12 +393,10 @@ sub ssh_start
 sub ssh_stop
 {
 	my ($self) = @_;
-	my $user = $self->{'ssh_user'}; 
+	my $user = $self->{'ssh_user'};
 
 	run_string($self, "exit");
-	if ($user ne 'root') {
-		run_string($self, "exit");
-	}
+	run_string($self, "exit") if ($user ne 'root');
 
 	waitpid($self->{'pid'}, 0);
 }


### PR DESCRIPTION
If the root access is forbidden by ssh, you should specify
a different user. To gain root, we will use "sudo su".
This is common for public cloud instances.