### PR TITLE
runltp_ng(ssh): Do not ping before ssh connect

### DIFF
--- a/tools/runltp-ng/backend.pm
+++ b/tools/runltp-ng/backend.pm
@@ -351,13 +351,8 @@ sub ssh_start
 	my ($self) = @_;
 	my $host = $self->{'ssh_host'};
 
-	msg("Waiting for $host to appear\n");
-	while (system("ping -c 1 $host >/dev/null 2>&1")) {
-		sleep(1);
-	}
-
 	msg("Waiting for sshd to accept connections\n");
-	while (system("echo | nc $host 22 >/dev/null 2>&1")) {
+	while (system("echo | nc -w1 $host 22 >/dev/null 2>&1")) {
 		sleep(1);
 	}
 


### PR DESCRIPTION
Do not check ping, before trying ssh connection. It's not necessary
that the host is reachable via IGMP.