### PR TITLE
 runltp-ng: Exclude tests from testgroup 

### DIFF
--- a/tools/runltp-ng/runltp-ng
+++ b/tools/runltp-ng/runltp-ng
@@ -34,6 +34,7 @@ my $sysinfo;
 my $verbose;
 my $list;
 my $run;
+my $exclude;
 my $install;
 
 GetOptions("backend=s" => \$backend_opts,
@@ -42,6 +43,7 @@ GetOptions("backend=s" => \$backend_opts,
            "sysinfo" => \$sysinfo,
            "list" => \$list,
            "run=s" => \$run,
+           "exclude=s" => \$exclude,
            "install=s" => \$install,
            "verbose" => \$verbose)
 or die("Error in argument parsing!\n");
@@ -54,6 +56,7 @@ if ($help) {
 	print("--list             : List test groups\n\n");
 	print("--verbose          : Enables verbose mode\n\n");
 	print("--run=testgroup    : Execute group of tests\n\n");
+	print("--exclude=regex    : Exclude tests from test group\n\n");
 	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
 	print("Backend help\n------------\n\n");
 	print("--backend=sh|...[:param=val]...\n\n");
@@ -90,7 +93,7 @@ if ($install) {
 if ($run) {
 	my %results;
 	$results{'sysinfo'} = utils::collect_sysinfo($backend);
-	my ($stats, $test_results) = utils::run_ltp($backend, $run);
+	my ($stats, $test_results) = utils::run_ltp($backend, $run, $exclude);
 	$results{'tests'} = {'stats' => $stats, 'results' => $test_results};
 	results::writelog(\%results, "$logname.json");
 	results::writelog_html(\%results, "$logname.html");

--- a/tools/runltp-ng/utils.pm
+++ b/tools/runltp-ng/utils.pm
@@ -291,7 +291,7 @@ sub reboot
 
 sub run_ltp
 {
-	my ($self, $runtest) = @_;
+	my ($self, $runtest, $exclude) = @_;
 	my @results;
 	my %reshash;
 
@@ -321,6 +321,7 @@ sub run_ltp
 		next if m/^\s*($|#)/;
 		chomp;
 		my ($tid, $c) = split(/\s/, $_, 2);
+		next if ($exclude && $tid =~ $exclude);
 		print("Executing $tid\n");
 		my $test_start_time = clock_gettime(CLOCK_MONOTONIC);
 		my ($ret, @log) = backend::run_cmd($self, "$c", 600);


### PR DESCRIPTION
Add optional parameter --exclude. Given regex is used to exclude
tests from testgroup.