### PR TITLE
runltp-ng: do not return undef in read_file()

### DIFF
--- a/tools/runltp-ng/backend.pm
+++ b/tools/runltp-ng/backend.pm
@@ -525,7 +525,7 @@ sub read_file
 
 	if ($res[0] != 0) {
 		print("Failed to read file $path");
-		return undef;
+		return;
 	}
 
 	return @res[2 .. $#res];


### PR DESCRIPTION
Return empty array in array-context and undef in scalar context.
This avoid "Use of uninitialized value" warning.