### PR TITLE
[RFC] runltp-ng: Recover on timeout

### DIFF
--- a/tools/runltp-ng/backend.pm
+++ b/tools/runltp-ng/backend.pm
@@ -179,6 +179,24 @@ sub run_cmd
 	wantarray? ($ret, @log) : $ret;
 }
 
+sub run_cmds
+{
+	my ($self, $cmds,%args) = @_;
+	my @log;
+
+	push(@log, {cmd=>'', ret=>0, log=>''}) unless (@{$cmds});
+
+	for my $cmd (@{$cmds}) {
+		my @ret = run_cmd($self, $cmd, $args{timeout});
+		my @output = @ret[1 .. $#ret];
+		push(@log, {cmd=>$cmd, ret=>$ret[0], log => \@output});
+
+		return wantarray? @log : $ret[0]
+		unless (defined($ret[0]) && $ret[0] == 0);
+	}
+	return wantarray? @log : 0;
+}
+
 sub start
 {
 	my ($self) = @_;
@@ -522,7 +540,9 @@ sub set_logfile
 sub check_cmd
 {
 	my ($self, $cmd) = @_;
-	return run_cmd($self, $cmd) != 127;
+	my $ret = run_cmd($self, $cmd);
+	return unless(defined($ret));
+	return $ret != 127;
 }
 
 sub read_file


### PR DESCRIPTION
Improve timeout handling. The idea is to retry the sequence of
commands once one failed in timeout.
The reboot function of the backend is used to recover the SUT.

This is a approach of how we could handle the timeout. If it goes in the right direction
I will change all the other shell command calls.
