### PR TITLE
runltp-ng: Set TMPDIR and LTPROOT environment

### DIFF
--- a/tools/runltp-ng/utils.pm
+++ b/tools/runltp-ng/utils.pm
@@ -273,9 +273,11 @@ sub setup_ltp_run
 	my @tests;
 
 	backend::run_cmd($self, "cd /opt/ltp/");
+	backend::run_cmd($self, 'export LTPROOT=$PWD');
+	backend::run_cmd($self, 'export TMPDIR=/tmp');
+	backend::run_cmd($self, 'export PATH=$LTPROOT/testcases/bin:$PATH');
 	@tests = backend::read_file($self, "runtest/$runtest") if defined($runtest);
-	backend::run_cmd($self, "cd testcases/bin");
-	backend::run_cmd($self, "export PATH=\$PATH:\$PWD");
+	backend::run_cmd($self, 'cd $LTPROOT/testcases/bin');
 
 	return \@tests;
 }


### PR DESCRIPTION
Discovered problem with test utimensat01, as it didn't found the
executable cause LTPROOT was set wrong.

```
sh-4.4# utimensat_tests.sh; echo cmd-exit-1040-$?
utimensat01 1 TBROK: /opt/ltp/testcases/bin/testcases/bin/utimensat01 is missing (please check install)
```