### PR TITLE
Fix typos and clean up grammar in README.md

### DIFF
--- a/docparse/README.md
+++ b/docparse/README.md
@@ -4,25 +4,25 @@ Motivation for metadata exctraction
 Exporting documentation
 -----------------------
 
-This will allow us to build a browseable documentation for the testcases, e.g.
-catalogue of tests that would be searchable etc. At this point there is a
-single page generated from the extracted data that tries to outline the intend.
+This will allow us to build browseable documentation for the testcases, e.g.
+a catalogue of test information that would be searchable etc. At this point there is a
+single page generated from the extracted data that tries to outline the intent.
 
 
 Propagating test requirements
 -----------------------------
 
-Some subtest require differnt hardware resources/software versions/etc. the
-test execution framework needs to consume these so that it could locate proper
+Some subtests require differnt hardware resources/software versions/etc. the
+test execution framework needs to consume these so that it can locate proper
 hardware, install proper software, etc.
 
-Some examples of requriments are for example:
+Some examples of requriments are:
 
-* Test needs at least 1GB or RAM.
+* Test needs at least 1GB of RAM.
 
 * Test needs a block device at least 512MB in size
 
-* Test needs a numa machine with two memory nodes and at least 300 free pages on each node
+* Test needs a NUMA machine with two memory nodes and at least 300 free pages on each node
 
 * Test needs i2c eeprom connected on a i2c bus
 
@@ -30,11 +30,11 @@ Some examples of requriments are for example:
 
 
 With this information extracted from the tests the testrunner can then map the
-requiremnts on the available machines in a lab and select proper machine for
-the particular (sub)set of testcases as well as supply particular test with
+requiremnts on the available machines in a lab and select a proper machine for
+the particular (sub)set of testcases as well as supply a particular test with
 additional information needed for the test, such as address of the i2c device,
-paths to the serial devices, etc. In a case of virtual machines the test could
-also dynamically prepare correct environment for the test on demand.
+paths to the serial devices, etc. In the case of virtual machines the test could
+also dynamically prepare the correct environment for the test on demand.
 
 
 Parallel test execution
@@ -43,7 +43,7 @@ Parallel test execution
 An LTP testrun on a modern hardware wastes most of the machine resources
 because the testcases are running sequentially. However in order to execute
 tests in parallel we need to know which system resources are utilized by a
-given test as obviously we cannot run two tests that monopolize the same
+given test, as obviously we cannot run two tests that monopolize the same
 resource.
 
 Examples of such tests are:
@@ -65,16 +65,16 @@ Getting rid of runtest files
 ----------------------------
 
 This would also allow us to get rid of the unflexible and hard to maintain
-runtest files. Once this system is in place we will have a list of all test
-along with the metadata which means that we will be able to generate subsets of
+runtest files. Once this system is in place we will have a list of all tests
+along with their respective metadata - which means that we will be able to generate subsets of
 the test easily on the fly.
 
 In order to achieve this we need two things:
 
-Each test will escribe which syscall/functionality it tests in the metadata
-then we could define groups of tests based on that. I.e. instead of having
+Each test will describe which syscall/functionality it tests in the metadata.
+Then we could define groups of tests based on that. I.e. instead of having
 syscall runtest file we would ask the testrunner to run all test that have a
-defined which syscall they test, or whose filename match syscall name.
+defined which syscall they test, or whose filename matches a particular syscall name.
 
 Secondly we will have to store the test variants in the test metadata instead
 of putting them in a file that is unrelated to the test.
@@ -96,16 +96,17 @@ extract code comments and C structures. The docparser then runs over all C
 sources in the testcases directory and if tst\_test structure is present in the
 source it's parsed and the result is included in the resulting metadata.
 
-During parsing the metadata is stored in a simple key value storage that more
+During parsing the metadata is stored in a simple key/value storage that more
 or less follows C structure layout, i.e. can include hash, array, and string.
-Once the parsing is finished the result is filtered so that only intereting
-fields of the tst\_test structure are included and then converted into a JSON.
+Once the parsing is finished the result is filtered so that only interesting
+fields of the tst\_test structure are included and then converted into JSON
+output.
 
-This process produces one big JSON file that with metadata for all tests that
-is then installed along with the testcases which then would be used by the
+This process produces one big JSON file with metadata for all tests, that
+is then installed along with the testcases. This would then be used by the
 testrunner.
 
-The test requirements are stored in the tst\_test structure either as a
+The test requirements are stored in the tst\_test structure either as
 bitflags, integers or arrays of strings:
 
 ```c
@@ -203,15 +204,15 @@ The final JSON file is an array of test descriptions such as this one.
 Open Points
 ===========
 
-There are stil some loose ends, mostly it's not well defined where to put
+There are stil some loose ends. Mostly it's not well defined where to put
 things and how to format them.
 
-* Some of the hardware requirements are already listed in the tst\_test should
+* Some of the hardware requirements are already listed in the tst\_test. Should
   we put all of them there?
 
 * What would be the format for test documentation and how to store things such
   as test variants there?
 
-So far this proof of concept generates a metadata file, I guess that we need
+So far this proof of concept generates a metadata file. I guess that we need
 actual consumers which will help to settle things down, I will try to look into
-making use of this in the runltp-ng at least as reference implementation.
+making use of this in the runltp-ng at least as a reference implementation.


### PR DESCRIPTION
Clean up the README.md file  to improve its grammar.  Make verbs and subjects agree.
Split a few sentences for clarity.  Fix some mis-spelled words.  Add a few missing participles
and conjunctions.